### PR TITLE
6 design and implement engine script module

### DIFF
--- a/Core/src/core/MainLoop.cpp
+++ b/Core/src/core/MainLoop.cpp
@@ -25,7 +25,8 @@ void core::MainLoop::start(double ups, double fps)
 	
 		while (accumulator >= dt)
 		{
-			m_processor(t, dt);
+			if (m_running)
+				m_processor(t, dt);
 			accumulator -= dt;
 			t += dt;
 		}

--- a/Core/src/core/Resources.h
+++ b/Core/src/core/Resources.h
@@ -29,6 +29,14 @@ namespace core
 	}
 
 	/**
+		All script modules are specified in this namespace.
+	*/
+	namespace res::script
+	{
+		const std::string ENGINE = "engine";
+	}
+
+	/**
 		All special assets which should receive special names.
 	*/
 	namespace res::asset

--- a/Core/src/script/ScriptUtil.hpp
+++ b/Core/src/script/ScriptUtil.hpp
@@ -37,7 +37,7 @@ namespace core::util
 	template<typename Type>
 	void addGlobalVariable(Script & script, Type && variable, const std::string & name)
 	{
-		script.handle().add_global(chaiscript::const_var(variable), name);
+		script.handle().add_global(chaiscript::var(variable), name);
 	}
 	template<typename Type>
 	void addGlobalConstant(Script & script, const Type & variable, const std::string & name)

--- a/Vox/Vox.vcxproj
+++ b/Vox/Vox.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\core\Engine.cpp" />
+    <ClCompile Include="src\core\ScriptModules.cpp" />
     <ClCompile Include="src\core\Setup.cpp" />
     <ClCompile Include="src\editor\util\Cursor.cpp" />
     <ClCompile Include="src\editor\util\CameraHandler.cpp" />
@@ -63,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\core\Engine.h" />
+    <ClInclude Include="src\core\ScriptModules.h" />
     <ClInclude Include="src\core\Setup.h" />
     <ClInclude Include="src\editor\EditorWorld.h" />
     <ClInclude Include="src\editor\util\Cursor.h" />

--- a/Vox/Vox.vcxproj.filters
+++ b/Vox/Vox.vcxproj.filters
@@ -97,12 +97,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\editor\util\Cursor.cpp">
-	  <Filter>Source Files</Filter>
+      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\editor\util\CameraHandler.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\editor\util\Grid.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\core\ScriptModules.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -209,8 +212,8 @@
     <ClInclude Include="src\world\Universe.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-	<ClInclude Include="src\editor\EditorWorld.h">
-	  <Filter>Header Files</Filter>
+    <ClInclude Include="src\editor\EditorWorld.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\world\render\WorldRender.h">
       <Filter>Header Files</Filter>
@@ -222,6 +225,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\editor\util\Grid.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\core\ScriptModules.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Vox/src/core/Engine.cpp
+++ b/Vox/src/core/Engine.cpp
@@ -82,6 +82,7 @@ void core::Engine::initialize()
 	setupComponents(getECS());
 	setupSystems(getECS());
 	setupUBOs(getUBOs());
+	setupModules(getModules());
 
 	m_impl->m_universe.prepare(getAssets());
 }
@@ -115,6 +116,7 @@ core::Display & core::Engine::getDisplay() { return m_impl->m_display; }
 core::ECS & core::Engine::getECS() { return m_impl->m_ecs; }
 core::EventBus & core::Engine::getEventBus() { return m_impl->m_bus; }
 core::GuiRegistry & core::Engine::getGuiRegistry() { return m_impl->m_guis; }
+core::ModuleRegistry & core::Engine::getModules() { return m_impl->m_modules; }
 core::Scene & core::Engine::getScene() { return m_impl->m_scene; }
 core::StateManager & core::Engine::getStates() { return m_impl->m_states; }
 core::UBORegistry & core::Engine::getUBOs() { return m_impl->m_ubos; }

--- a/Vox/src/core/Engine.cpp
+++ b/Vox/src/core/Engine.cpp
@@ -82,7 +82,7 @@ void core::Engine::initialize()
 	setupComponents(getECS());
 	setupSystems(getECS());
 	setupUBOs(getUBOs());
-	setupModules(getModules());
+	setupModules(getModules(), *this);
 
 	m_impl->m_universe.prepare(getAssets());
 }

--- a/Vox/src/core/Engine.h
+++ b/Vox/src/core/Engine.h
@@ -11,6 +11,7 @@ namespace core
 	class ECS;
 	class EventBus;
 	class GuiRegistry;
+	class ModuleRegistry;
 	class Scene;
 	class StateManager;
 	class UBORegistry;
@@ -46,6 +47,7 @@ namespace core
 		ECS & getECS();
 		EventBus & getEventBus();
 		GuiRegistry & getGuiRegistry();
+		ModuleRegistry & getModules();
 		Scene & getScene();
 		StateManager & getStates();
 		UBORegistry & getUBOs();

--- a/Vox/src/core/ScriptModules.cpp
+++ b/Vox/src/core/ScriptModules.cpp
@@ -1,6 +1,11 @@
 
 #include "ScriptModules.h"
 
-void core::script::initializeEngine(Script & script)
+#include "core/Engine.h"
+#include "script/ScriptUtil.h"
+
+void core::script::initializeEngine(Script & script, Engine & engine)
 {
+	util::addGlobalVariable(script, &engine, "ENGINE");
+	util::addMethod(script, &Engine::stop, "stop");
 }

--- a/Vox/src/core/ScriptModules.cpp
+++ b/Vox/src/core/ScriptModules.cpp
@@ -1,0 +1,6 @@
+
+#include "ScriptModules.h"
+
+void core::script::initializeEngine(Script & script)
+{
+}

--- a/Vox/src/core/ScriptModules.h
+++ b/Vox/src/core/ScriptModules.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace core
+{
+	class Script;
+
+	/**
+		No script module will be applied to a script unless explicitly stated. In order to add a
+		module to a script, ModuleRegistry should be used. It can apply any number of named modules
+		to a given script.
+	*/
+	namespace script
+	{
+		/**
+			Initializes the engine module of the scripting system. The engine module contains
+			functionality which directly applies to the engine itself.
+
+			@param script The script which should be initialized with the module.
+		*/
+		void initializeEngine(Script & script);
+	}
+}

--- a/Vox/src/core/ScriptModules.h
+++ b/Vox/src/core/ScriptModules.h
@@ -2,6 +2,7 @@
 
 namespace core
 {
+	class Engine;
 	class Script;
 
 	/**
@@ -16,7 +17,8 @@ namespace core
 			functionality which directly applies to the engine itself.
 
 			@param script The script which should be initialized with the module.
+			@param engine The game engine itself.
 		*/
-		void initializeEngine(Script & script);
+		void initializeEngine(Script & script, Engine & engine);
 	}
 }

--- a/Vox/src/core/Setup.cpp
+++ b/Vox/src/core/Setup.cpp
@@ -43,7 +43,7 @@ void core::setupUBOs(UBORegistry & ubos)
 	ubos.build(res::ubo::MATRICES);
 }
 
-void core::setupModules(ModuleRegistry & modules)
+void core::setupModules(ModuleRegistry & modules, Engine & engine)
 {
-	modules.add(res::script::ENGINE, script::initializeEngine);
+	modules.add(res::script::ENGINE, [&engine](auto & script) { script::initializeEngine(script, engine); });
 }

--- a/Vox/src/core/Setup.cpp
+++ b/Vox/src/core/Setup.cpp
@@ -5,10 +5,12 @@
 #include "allegro/SpriteFactory.h"
 #include "asset/AssetUtil.h"
 #include "core/Resources.h"
+#include "core/ScriptModules.h"
 #include "ecs/ECS.h"
 #include "opengl/ProgramFactory.h"
 #include "opengl/UBORegistry.h"
 #include "scene/RenderComponent.h"
+#include "script/ModuleRegistry.h"
 #include "world/render/BlockTextureAtlas.h"
 
 #include <glm/mat4x4.hpp>
@@ -39,4 +41,9 @@ void core::setupUBOs(UBORegistry & ubos)
 	ubos.add<glm::mat4>(res::ubo::MATRICES, res::ubo::VIEW);
 	ubos.add<glm::mat4>(res::ubo::MATRICES, res::ubo::MODEL);
 	ubos.build(res::ubo::MATRICES);
+}
+
+void core::setupModules(ModuleRegistry & modules)
+{
+	modules.add(res::script::ENGINE, script::initializeEngine);
 }

--- a/Vox/src/core/Setup.h
+++ b/Vox/src/core/Setup.h
@@ -8,6 +8,7 @@ namespace core
 {
 	class AssetRegistry;
 	class ECS;
+	class Engine;
 	class ModuleRegistry;
 	class UBORegistry;
 
@@ -53,6 +54,7 @@ namespace core
 		Sets up the different script modules which adds various functionality to scripts.
 
 		@param modules The module registry which should contain all script modules in the system.
+		@param engine The game engine itself.
 	*/
-	void setupModules(ModuleRegistry & modules);
+	void setupModules(ModuleRegistry & modules, Engine & engine);
 }

--- a/Vox/src/core/Setup.h
+++ b/Vox/src/core/Setup.h
@@ -8,6 +8,7 @@ namespace core
 {
 	class AssetRegistry;
 	class ECS;
+	class ModuleRegistry;
 	class UBORegistry;
 
 	/**
@@ -47,4 +48,11 @@ namespace core
 		@param ubos The registry containing all uniform buffer objects.
 	*/
 	void setupUBOs(UBORegistry & ubos);
+
+	/**
+		Sets up the different script modules which adds various functionality to scripts.
+
+		@param modules The module registry which should contain all script modules in the system.
+	*/
+	void setupModules(ModuleRegistry & modules);
 }

--- a/VoxTest/VoxTest.vcxproj
+++ b/VoxTest/VoxTest.vcxproj
@@ -176,6 +176,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="src\core\ScriptModuleTest.cpp" />
     <ClCompile Include="src\editor\util\CursorTest.cpp" />
     <ClCompile Include="src\editor\util\CameraHandlerTest.cpp" />
     <ClCompile Include="src\editor\util\GridTest.cpp" />

--- a/VoxTest/VoxTest.vcxproj.filters
+++ b/VoxTest/VoxTest.vcxproj.filters
@@ -94,12 +94,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\editor\util\CursorTest.cpp">
-	  <Filter>Source Files</Filter>
+      <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\editor\util\CameraHandlerTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\editor\util\GridTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\core\ScriptModuleTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/VoxTest/src/core/ScriptModuleTest.cpp
+++ b/VoxTest/src/core/ScriptModuleTest.cpp
@@ -1,0 +1,56 @@
+
+#include "core/ScriptModules.h"
+
+#include "core/Engine.h"
+#include "script/Script.h"
+#include "state/State.h"
+#include "state/StateManager.h"
+
+#include <functional>
+
+#include "CppUnitTest.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace
+{
+	/**
+		The mock state accepts a callback which should be invoked every tick while the state is
+		active. If the specified number of cycles ticks by without the callback terminating the
+		engine, the test is considered failed.
+	*/
+	class MockState : public core::State
+	{
+	public:
+		MockState(int cycles, const std::function<void()> & callback) : m_cycles(cycles), m_callback(callback) {}
+
+		virtual void initialize(core::Engine & engine) override final {}
+		virtual void process() override final { if (m_cycles-- <= 0) Assert::Fail(); m_callback(); }
+
+	private:
+		int m_cycles;
+
+		std::function<void()> m_callback;
+	};
+}
+
+namespace core::setup
+{
+	TEST_CLASS(ScriptModuleTest)
+	{
+	public:
+		TEST_METHOD(ScriptModule_initializeEngine)
+		{
+			Engine engine;
+			engine.initialize();
+			engine.getStates().set<MockState>(1, [this]() { m_script.execute("ENGINE.stop()"); });
+
+			script::initializeEngine(m_script, engine);
+
+			engine.start();
+		}
+
+	private:
+		Script m_script{ "script" };
+	};
+}


### PR DESCRIPTION
Closes #6, adds a basic setup for registering script modules. Fixes a bug with registering global variables, and terminating main loop.