### PR TITLE
32 hierarchial widget naming

### DIFF
--- a/Core/src/asset/AssetUtil.cpp
+++ b/Core/src/asset/AssetUtil.cpp
@@ -5,11 +5,11 @@
 
 void core::detail::logSearchingFolder(const util::Folder & folder)
 {
-	LOG_INFO << "Searching '" << folder.path() << "'...";
+	LOG_DEBUG << "Searching '" << folder.path() << "'...";
 }
 void core::detail::logFoundValidAsset(const util::File & file)
 {
-	LOG_INFO << "Found '" << file.path() << "'...";
+	LOG_DEBUG << "Found '" << file.path() << "'...";
 }
 void core::detail::logCreatedFactory(const std::string & name)
 {

--- a/Core/src/gui/Widget.h
+++ b/Core/src/gui/Widget.h
@@ -109,6 +109,8 @@ namespace core
 
 		// ...
 
+		std::string m_name = "root";
+
 		std::unique_ptr<Handler> m_handler;
 		std::unique_ptr<Renderer> m_renderer;
 		std::unique_ptr<Processor> m_processor;
@@ -116,7 +118,7 @@ namespace core
 		BoundingBox m_bbox;
 		Border m_border;
 		Family m_family;
-		Group m_group{ this, { this } };
+		Group m_group = { this, { this } };
 		Link m_link;
 		State m_state;
 		Value m_value;

--- a/Core/src/gui/WidgetLoader.cpp
+++ b/Core/src/gui/WidgetLoader.cpp
@@ -65,7 +65,10 @@ void core::WidgetLoader::load(const pugi::xml_node & node, Widget & widget)
 	else if (const auto it = m_widgets.find(widget.m_name); it != m_widgets.end())
 		LOG_WARNING << "Cannot overwrite existing widget " << widget.m_name;
 	else
+	{
 		m_widgets[widget.m_name] = &widget;
+		LOG_DEBUG << "Loading widget '" << widget.m_name << "'...";
+	}
 
 	// Must load normal data and specialization before children
 	if (const auto data = node.child("border"))

--- a/Core/src/gui/WidgetLoader.h
+++ b/Core/src/gui/WidgetLoader.h
@@ -101,6 +101,30 @@ namespace core
 		void loadSlider(const pugi::xml_node & node, Widget & widget);
 
 	private:
+		/**
+			Retrieves the fully qualified name for a widget with the given name and, if present, the
+			given parent. The fully qualified name will be the name of the parent concatenated with
+			the name of the child widget, seperated by a period character.
+
+			@param name The name of the child widget. Must not contain any periods.
+			@param parent The parent of the child widget, if it has any parents.
+			@return The fully qualified name of the widget, on the form "parent.child".
+		*/
+		std::string getFullName(const std::string & name, const Widget * parent) const;
+
+		/**
+			Attempts to locate the widget with the given name. The name must not be a fully
+			qualified name. If the parent is specified, the widget will be a child of the parent
+			with the given name.
+
+			@param name The name of the widget to located.
+			@param parent The parent of the widget to locate.
+			@return The widget, or nullptr if it could not be located.
+		*/
+		Widget * getWidget(const std::string & name, const Widget * parent) const;
+
+		// ...
+
 		const AssetRegistry & m_assets;
 		const Script & m_script;
 		EventBus & m_bus;

--- a/Game/data/guis/editor_world.xml
+++ b/Game/data/guis/editor_world.xml
@@ -13,50 +13,50 @@
         <renderer background="gui/generic/background" />
       </panel>
       
-      <widget name="reach_axis">
+      <widget name="lock_label">
         <bbox size="103, 16" />
         <border outer="3" />
         <label>
           <renderer pretext="Locked axis" font="overlock" />
         </label>
       </widget>
-      <widget name="reach_lock_x">
+      <widget name="lock_x">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="reach_axis" ratio="2, 0" />
+        <link target="lock_label" ratio="2, 0" />
         <button type="checkbox">
           <renderer button="gui/editor_world/util/axis_x" />
         </button>
       </widget>
-      <widget name="reach_lock_y">
+      <widget name="lock_y">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="reach_lock_x" ratio="2, 0" />
+        <link target="lock_x" ratio="2, 0" />
         <button type="checkbox">
           <renderer button="gui/editor_world/util/axis_y" />
         </button>
       </widget>
-      <widget name="reach_lock_z">
+      <widget name="lock_z">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="reach_lock_y" ratio="2, 0" />
+        <link target="lock_y" ratio="2, 0" />
         <button type="checkbox">
           <renderer button="gui/editor_world/util/axis_z" />
         </button>
       </widget>
       
-      <widget name="reach_label">
+      <widget name="distance_label">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="reach_axis" ratio="0, 2" />
+        <link target="lock_label" ratio="0, 2" />
         <label>
           <renderer pretext="Reach distance" font="overlock" />
         </label>
       </widget>
-      <widget name="reach_distance">
+      <widget name="distance">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="reach_label" ratio="0, 2" />
+        <link target="distance_label" ratio="0, 2" />
         <slider>
           <data min="1" max="2500" center="100" step="1" />
           <renderer button_decrement="gui/generic/arrow_left"
@@ -65,10 +65,10 @@
         </slider>
       </widget>
       
-      <widget name="reach_hit_blocks">
+      <widget name="hit_blocks">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="reach_distance" ratio="0, 2" />
+        <link target="distance" ratio="0, 2" />
         <button type="checkbox">
           <renderer button="gui/generic/checkbox" />
         </button>
@@ -76,15 +76,15 @@
       <widget>
         <bbox size="141, 16" />
         <border outer="3" />
-        <link target="reach_hit_blocks" ratio="2, 0" />
+        <link target="hit_blocks" ratio="2, 0" />
         <label>
           <renderer pretext="Intersect blocks" font="overlock" />
         </label>
       </widget>
-      <widget name="reach_hit_last">
+      <widget name="hit_last">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="reach_hit_blocks" ratio="0, 2" />
+        <link target="hit_blocks" ratio="0, 2" />
         <button type="checkbox">
           <renderer button="gui/generic/checkbox" />
         </button>
@@ -92,15 +92,15 @@
       <widget>
         <bbox size="141, 16" />
         <border outer="3" />
-        <link target="reach_hit_last" ratio="2, 0" />
+        <link target="hit_last" ratio="2, 0" />
         <label>
           <renderer pretext="Select last air block" font="overlock" />
         </label>
       </widget>
-      <widget name="reach_hit_grid">
+      <widget name="hit_grid">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="reach_hit_last" ratio="0, 2" />
+        <link target="hit_last" ratio="0, 2" />
         <button type="checkbox">
           <renderer button="gui/generic/checkbox" />
         </button>
@@ -108,7 +108,7 @@
       <widget>
         <bbox size="141, 16" />
         <border outer="3" />
-        <link target="reach_hit_grid" ratio="2, 0" />
+        <link target="hit_grid" ratio="2, 0" />
         <label>
           <renderer pretext="Intersect grid" font="overlock" />
         </label>
@@ -122,17 +122,17 @@
         <renderer background="gui/generic/background" />
       </panel>
       
-      <widget name="camera_label">
+      <widget name="sensitivity_label">
         <bbox size="160, 16" />
         <border outer="3" />
         <label>
           <renderer pretext="Camera sensitivity" font="overlock" />
         </label>
       </widget>
-      <widget name="camera_sensitivity">
+      <widget name="sensitivity">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="camera_label" ratio="0, 2" />
+        <link target="sensitivity_label" ratio="0, 2" />
         <slider>
           <data min="0.1" max="2.5" center="1" step="0.1" />
           <renderer button_decrement="gui/generic/arrow_left"
@@ -149,17 +149,17 @@
         <renderer background="gui/generic/background" />
       </panel>
 
-      <widget name="grid_label">
+      <widget name="height_label">
         <bbox size="160, 16" />
         <border outer="3" />
         <label>
           <renderer pretext="Grid height" font="overlock" />
         </label>
       </widget>
-      <widget name="grid_height">
+      <widget name="height">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="grid_label" ratio="0, 2" />
+        <link target="height_label" ratio="0, 2" />
         <slider>
           <data min="-100" max="100" center="0" step="1" />
           <renderer button_decrement="gui/generic/arrow_left"
@@ -167,10 +167,10 @@
                     button_increment="gui/generic/arrow_right" />
         </slider>
       </widget>
-      <widget name="grid_offset_camera">
+      <widget name="offset_camera">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="grid_height" ratio="0, 2" />
+        <link target="height" ratio="0, 2" />
         <button type="checkbox">
           <renderer button="gui/generic/checkbox" />
         </button>
@@ -178,16 +178,16 @@
       <widget>
         <bbox size="141, 16" />
         <border outer="3" />
-        <link target="grid_offset_camera" ratio="2, 0" />
+        <link target="offset_camera" ratio="2, 0" />
         <label>
           <renderer pretext="Offset from camera" font="overlock" />
         </label>
       </widget>
 
-      <widget name="grid_visible">
+      <widget name="visible">
         <bbox size="16, 16" />
         <border outer="3" />
-        <link target="grid_offset_camera" ratio="0, 2" />
+        <link target="offset_camera" ratio="0, 2" />
         <button type="checkbox">
           <renderer button="gui/generic/checkbox" />
         </button>
@@ -195,24 +195,24 @@
       <widget>
         <bbox size="141, 16" />
         <border outer="3" />
-        <link target="grid_visible" ratio="2, 0" />
+        <link target="visible" ratio="2, 0" />
         <label>
           <renderer pretext="Grid visibility" font="overlock" />
         </label>
       </widget>
 
-      <widget name="grid_size_label">
+      <widget name="size_label">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="grid_visible" ratio="0, 2" />
+        <link target="visible" ratio="0, 2" />
         <label>
           <renderer pretext="Cell count/size" font="overlock" />
         </label>
       </widget>
-      <widget name="grid_size">
+      <widget name="size">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="grid_size_label" ratio="0, 2" />
+        <link target="size_label" ratio="0, 2" />
         <slider>
           <data min="1" max="50" center="25" step="1" />
           <renderer button_decrement="gui/generic/arrow_left"
@@ -220,10 +220,10 @@
                     button_increment="gui/generic/arrow_right" />
         </slider>
       </widget>
-      <widget name="grid_spacing">
+      <widget name="spacing">
         <bbox size="160, 16" />
         <border outer="3" />
-        <link target="grid_size" ratio="0, 2" />
+        <link target="size" ratio="0, 2" />
         <slider>
           <data min="1" max="10" center="5" step="1" />
           <renderer button_decrement="gui/generic/arrow_left"
@@ -241,44 +241,44 @@
       <renderer background="gui/generic/background" />
     </panel>
 
-    <widget name="tool_brush">
+    <widget name="brush">
       <bbox size="32, 32" />
       <border outer="3" />
       <button type="radio">
         <renderer button="gui/editor_world/tools/brush" />
       </button>
     </widget>
-    <widget name="tool_delete">
+    <widget name="delete">
       <bbox size="32, 32" />
       <border outer="3" />
-      <link target="tool_brush" ratio="2, 0" />
+      <link target="brush" ratio="2, 0" />
       <button>
         <renderer button="gui/editor_world/tools/delete" />
       </button>
     </widget>
-    <widget name="tool_pull">
+    <widget name="pull">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="tool_brush" />
-      <link target="tool_delete" ratio="2, 0" />
+      <group leader="brush" />
+      <link target="delete" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/tools/pull" />
       </button>
     </widget>
-    <widget name="tool_replace">
+    <widget name="replace">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="tool_brush" />
-      <link target="tool_pull" ratio="2, 0" />
+      <group leader="brush" />
+      <link target="pull" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/tools/replace" />
       </button>
     </widget>
-    <widget name="tool_smooth">
+    <widget name="smooth">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="tool_brush" />
-      <link target="tool_replace" ratio="2, 0" />
+      <group leader="brush" />
+      <link target="replace" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/tools/smooth" />
       </button>
@@ -293,45 +293,45 @@
       <renderer background="gui/generic/background" />
     </panel>
 
-    <widget name="shape_rectangle">
+    <widget name="rectangle">
       <bbox size="32, 32" />
       <border outer="3" />
       <button type="radio">
         <renderer button="gui/editor_world/shapes/box" />
       </button>
     </widget>
-    <widget name="shape_cylinder">
+    <widget name="cylinder">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="shape_rectangle" />
-      <link target="shape_rectangle" ratio="2, 0" />
+      <group leader="rectangle" />
+      <link target="rectangle" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/shapes/cylinder" />
       </button>
     </widget>
-    <widget name="shape_ellipse">
+    <widget name="ellipse">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="shape_rectangle" />
-      <link target="shape_cylinder" ratio="2, 0" />
+      <group leader="rectangle" />
+      <link target="cylinder" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/shapes/ellipse" />
       </button>
     </widget>
-    <widget name="shape_line">
+    <widget name="line">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="shape_rectangle" />
-      <link target="shape_ellipse" ratio="2, 0" />
+      <group leader="rectangle" />
+      <link target="ellipse" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/shapes/line" />
       </button>
     </widget>
-    <widget name="shape_point">
+    <widget name="point">
       <bbox size="32, 32" />
       <border outer="3" />
-      <group leader="shape_rectangle" />
-      <link target="shape_line" ratio="2, 0" />
+      <group leader="rectangle" />
+      <link target="line" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/shapes/point" />
       </button>
@@ -355,13 +355,13 @@
   <widget name="settings_shape_rectangle">
     <border inner="3" outer="3" />
     <link target="shapes" ratio="1, 2" />
-    <state visible="false" />
+    <state visible="true" />
     <panel>
       <renderer background="gui/generic/background" />
     </panel>
 
     <!-- Size settings -->
-    <widget name="shape_rectangle_dynamic_size">
+    <widget name="dynamic_size_label">
       <bbox size="141, 16" />
       <border outer="3" />
       <label>
@@ -371,16 +371,16 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_dynamic_size" ratio="2, 0" />
+      <link target="dynamic_size_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
 
-    <widget name="shape_rectangle_size_x">
+    <widget name="size_x">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_dynamic_size" ratio="0, 2" />
+      <link target="dynamic_size_label" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -389,10 +389,10 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_rectangle_size_y">
+    <widget name="size_y">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_size_x" ratio="0, 2" />
+      <link target="size_x" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -401,10 +401,10 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_rectangle_size_z">
+    <widget name="size_z">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_size_y" ratio="0, 2" />
+      <link target="size_y" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -414,10 +414,10 @@
       </slider>
     </widget>
 
-    <widget name="shape_rectangle_center">
+    <widget name="center_label">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_size_z" ratio="0, 2" />
+      <link target="size_z" ratio="0, 2" />
       <label>
         <renderer pretext="Expand from center" font="overlock" />
       </label>
@@ -425,17 +425,17 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_center" ratio="2, 0" />
+      <link target="center_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
 
     <!-- Hollow settings -->
-    <widget name="shape_rectangle_hollow">
+    <widget name="hollow_label">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_center" ratio="0, 2" />
+      <link target="center_label" ratio="0, 2" />
       <label>
         <renderer pretext="Hollow brush" font="overlock" />
       </label>
@@ -443,15 +443,15 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_hollow" ratio="2, 0" />
+      <link target="hollow_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
-    <widget name="shape_rectangle_thickness">
+    <widget name="thickness">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_rectangle_hollow" ratio="0, 2" />
+      <link target="hollow_label" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -466,51 +466,51 @@
   <widget name="settings_shape_cylinder">
     <border inner="3" outer="3" />
     <link target="shapes" ratio="1, 2" />
-    <state visible="true" />
+    <state visible="false" />
     <panel>
       <renderer background="gui/generic/background" />
     </panel>
 
     <!-- Axis settings -->
-    <widget name="shape_cylinder_axis">
+    <widget name="axis_label">
       <bbox size="103, 16" />
       <border outer="3" />
       <label>
         <renderer pretext="Axis" font="overlock" />
       </label>
     </widget>
-    <widget name="shape_cylinder_axis_x">
+    <widget name="axis_x">
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_axis" ratio="2, 0" />
+      <link target="axis_label" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/util/axis_x" />
       </button>
     </widget>
-    <widget name="shape_cylinder_axis_y">
+    <widget name="axis_y">
       <bbox size="16, 16" />
       <border outer="3" />
-      <group leader="shape_cylinder_axis_x" />
-      <link target="shape_cylinder_axis_x" ratio="2, 0" />
+      <group leader="axis_x" />
+      <link target="axis_x" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/util/axis_y" />
       </button>
     </widget>
-    <widget name="shape_cylinder_axis_z">
+    <widget name="axis_z">
       <bbox size="16, 16" />
       <border outer="3" />
-      <group leader="shape_cylinder_axis_x" />
-      <link target="shape_cylinder_axis_y" ratio="2, 0" />
+      <group leader="axis_x" />
+      <link target="axis_y" ratio="2, 0" />
       <button type="radio">
         <renderer button="gui/editor_world/util/axis_z" />
       </button>
     </widget>
 
     <!-- Size settings -->
-    <widget name="shape_cylinder_dynamic_size">
+    <widget name="dynamic_size_label">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_axis" ratio="0, 2" />
+      <link target="axis_label" ratio="0, 2" />
       <label>
         <renderer pretext="Fixed size" font="overlock" />
       </label>
@@ -518,16 +518,16 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_dynamic_size" ratio="2, 0" />
+      <link target="dynamic_size_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
 
-    <widget name="shape_cylinder_size_x">
+    <widget name="size_x">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_dynamic_size" ratio="0, 2" />
+      <link target="dynamic_size_label" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -536,10 +536,10 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_cylinder_size_y">
+    <widget name="size_y">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_size_x" ratio="0, 2" />
+      <link target="size_x" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -548,10 +548,10 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_cylinder_size_z">
+    <widget name="size_z">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_size_y" ratio="0, 2" />
+      <link target="size_y" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -561,10 +561,10 @@
       </slider>
     </widget>
 
-    <widget name="shape_cylinder_center">
+    <widget name="center_label">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_size_z" ratio="0, 2" />
+      <link target="size_z" ratio="0, 2" />
       <label>
         <renderer pretext="Expand from center" font="overlock" />
       </label>
@@ -572,7 +572,7 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_cylinder_center" ratio="2, 0" />
+      <link target="center_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
@@ -589,7 +589,7 @@
     </panel>
 
     <!-- Size settings -->
-    <widget name="shape_ellipse_dynamic_size">
+    <widget name="dynamic_size_label">
       <bbox size="141, 16" />
       <border outer="3" />
       <label>
@@ -599,16 +599,16 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_ellipse_dynamic_size" ratio="2, 0" />
+      <link target="dynamic_size_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
 
-    <widget name="shape_ellipse_size_x">
+    <widget name="size_x">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_ellipse_dynamic_size" ratio="0, 2" />
+      <link target="dynamic_size_label" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -617,10 +617,10 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_ellipse_size_y">
+    <widget name="size_y">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_ellipse_size_x" ratio="0, 2" />
+      <link target="size_x" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -629,10 +629,10 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_ellipse_size_z">
+    <widget name="size_z">
       <bbox size="160, 16" />
       <border outer="3" />
-      <link target="shape_ellipse_size_y" ratio="0, 2" />
+      <link target="size_y" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -642,10 +642,10 @@
       </slider>
     </widget>
 
-    <widget name="shape_ellipse_center">
+    <widget name="center_label">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_ellipse_size_z" ratio="0, 2" />
+      <link target="size_z" ratio="0, 2" />
       <label>
         <renderer pretext="Expand from center" font="overlock" />
       </label>
@@ -653,7 +653,7 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_ellipse_center" ratio="2, 0" />
+      <link target="center_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
@@ -671,7 +671,7 @@
     </panel>
 
     <!-- Size settings -->
-    <widget name="shape_line_dynamic_size">
+    <widget name="dynamic_size_label">
       <bbox size="141, 16" />
       <border outer="3" />
       <label>
@@ -681,16 +681,16 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_line_dynamic_size" ratio="2, 0" />
+      <link target="dynamic_size_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
 
-    <widget name="shape_line_size_x">
+    <widget name="size_x">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_line_dynamic_size" ratio="0, 2" />
+      <link target="dynamic_size_label" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -699,19 +699,19 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_line_size_x_invert">
+    <widget name="size_x_invert">
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_line_size_x" ratio="2, 0" />
+      <link target="size_x" ratio="2, 0" />
       <state locked="true" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
-    <widget name="shape_line_size_y">
+    <widget name="size_y">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_line_size_x" ratio="0, 2" />
+      <link target="size_x" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -720,19 +720,19 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_line_size_y_invert">
+    <widget name="size_y_invert">
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_line_size_y" ratio="2, 0" />
+      <link target="size_y" ratio="2, 0" />
       <state locked="true" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
-    <widget name="shape_line_size_z">
+    <widget name="size_z">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_line_size_y" ratio="0, 2" />
+      <link target="size_y" ratio="0, 2" />
       <state locked="true" />
       <slider type="horizontal">
         <data min="1" max="100" center="15" step="1" />
@@ -741,20 +741,20 @@
                   button_increment="gui/generic/arrow_right" />
       </slider>
     </widget>
-    <widget name="shape_line_size_z_invert">
+    <widget name="size_z_invert">
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_line_size_z" ratio="2, 0" />
+      <link target="size_z" ratio="2, 0" />
       <state locked="true" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>
     </widget>
 
-    <widget name="shape_line_center">
+    <widget name="center_label">
       <bbox size="141, 16" />
       <border outer="3" />
-      <link target="shape_line_size_z" ratio="0, 2" />
+      <link target="size_z" ratio="0, 2" />
       <label>
         <renderer pretext="Expand from center" font="overlock" />
       </label>
@@ -762,7 +762,7 @@
     <widget>
       <bbox size="16, 16" />
       <border outer="3" />
-      <link target="shape_line_center" ratio="2, 0" />
+      <link target="center_label" ratio="2, 0" />
       <button type="checkbox">
         <renderer button="gui/generic/checkbox" />
       </button>


### PR DESCRIPTION
Closes #32 

Restructures the internal naming of widgets such that the gui widget names can be simplified. For example, a snippet of a widget definition file containing
```xml
<widget name="foo">
    <widget name="baz" />
</widget>
<widget name="bar">
    <widget name="baz" />
</widget>
```
produces four widgets, "foo", "foo.baz", "bar", and "bar.baz".