### PR TITLE
Disallowing widgets to have the same name as each other

### DIFF
--- a/Core/src/gui/WidgetLoader.cpp
+++ b/Core/src/gui/WidgetLoader.cpp
@@ -65,12 +65,16 @@ void core::WidgetLoader::load(const pugi::xml_node & node, Widget & widget)
 	
 	// Can only store widgets with unique names
 	if (const auto it = m_widgets.find(widget.m_name); it != m_widgets.end())
-		LOG_WARNING << "Cannot overwrite existing widget " << widget.m_name;
-	else
 	{
-		m_widgets[widget.m_name] = &widget;
-		LOG_DEBUG << "Loading widget '" << widget.m_name << "'...";
+		LOG_WARNING << "Cannot overwrite existing widget " << widget.m_name;
+	
+		// Kill child if it does not have a unique name
+		if (widget.m_family.m_parent != nullptr)
+			widget.m_family.m_parent->m_family.m_children.pop_back();
+		return;
 	}
+	LOG_DEBUG << "Loading widget '" << widget.m_name << "'...";
+	m_widgets[widget.m_name] = &widget;
 
 	// Must load normal data and specialization before children
 	if (const auto data = node.child("border"))

--- a/CoreTest/src/gui/WidgetLoaderTest.cpp
+++ b/CoreTest/src/gui/WidgetLoaderTest.cpp
@@ -23,10 +23,12 @@ namespace core::gui
 			auto childA = addWidget(parent, "childA", "panel");
 			auto childB = addWidget(parent, "childB", "button");
 			auto childC = addWidget(childA, "childC", "button");
-			addWidget(m_root, "", "button");
+			addWidget(m_root, "", "button"); // Uses default name when no name is specified
+			addWidget(m_root, "parent", "button"); // Cannot load duplicated names
 
 			Widget root;
 			m_loader.load(m_root, root);
+			Assert::AreEqual(2u, root.m_family.m_children.size());
 			
 			auto & p = root.m_family.m_children[0];
 			auto & a = p->m_family.m_children[0];


### PR DESCRIPTION
Closes #31 